### PR TITLE
fix: langchain_tavily 패키지 설치 및 클래스명 수정 (#35)

### DIFF
--- a/core/chat_node.py
+++ b/core/chat_node.py
@@ -4,8 +4,8 @@ import json
 from langchain_core.exceptions import OutputParserException
 from typing import Dict, Any, Optional
 from datetime import datetime
-from langchain_community.tools import TavilySearchResults
-from typing import TypedDict, List, Dict
+from langchain_tavily import TavilySearch
+from typing import Dict
 from core.state import ConversationState
 import logging
 
@@ -158,15 +158,16 @@ class MissingSlotAsker(BaseNode):
 
 # Tavily 검색 노드
 class ExerciseSearchInfo(BaseNode):
-    def __init__(self, tool: Optional[TavilySearchResults] = None, top_k: int = 5):
-        self.tavily = tool or TavilySearchResults()
+    def __init__(self, tool: Optional[TavilySearch] = None, top_k: int = 5):
+        self.tavily = tool or TavilySearch()
         self.top_k = top_k
 
     def __call__(self, state: Dict[str, Any]) -> Dict[str, Any]:
         query = state.get("task_title") or state["user_input"]
         try:
             hits = self.tavily.invoke(query) or []
-            state["search_results"] = hits[: self.top_k]
+            results = hits.get("result", [])
+            state["search_results"] = results[: self.top_k]
             logger.info("Tavily 검색 쿼리: %s", query)
         except Exception as exc:
             logger.exception("Tavily search failed: %s", exc)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ langchain
 langchain_core 
 langchain_openai
 langchain_community
+langchain_tavily
 langgraph 
 
 fastapi


### PR DESCRIPTION
## ☝️Issue Number
- resolve #35 

## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 📌 개요
- LangChain에서 TavilySearchResults가 deprecated되어 langchain-tavily 패키지의 TavilySearch 클래스로 교체
- 검색 결과에 슬라이싱을 적용할 때 리스트가 아닌 dict 형식으로 바뀌어 KeyError: slice(None, 5, None) 예외가 발생하여 수정함

## ✅ 체크 리스트
- [X] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [X] PR이 관련 이슈를 정확히 참조하고, 적절한 라벨을 선택했습니다.
- [X] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 WIKI에 업데이트했습니다.
- [X] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.