### PR TITLE
fix: fetch_schedule 무한 호출 오류 수정 (#91)

### DIFF
--- a/core/chat_graph.py
+++ b/core/chat_graph.py
@@ -37,7 +37,7 @@ class ChatGraphBuilder:
         self.graph_builder.add_conditional_edges(
             "detect_intent",
             lambda state: (
-                "calendar_query" if state.get("intent") == "calendar"
+                "calendar_query" if state.get("intent") == "calendar" and not state.get("has_fetched_schedule")
                 else "detect_slot_and_category" if state.get("intent") in ["schedule", "confirm"]
                 else "general_qa"
             ),
@@ -133,6 +133,7 @@ class ChatGraphBuilder:
         self.graph_builder.add_edge("calendar_query", END)
 
     def compile(self):
+        logger.info("[ChatGraphBuilder] compile() called. Compiling chat graph.")
         self.add_node()
         self.set_entry_point()
         self.add_conditional_edges()

--- a/core/database.py
+++ b/core/database.py
@@ -1,8 +1,7 @@
 import asyncpg
 import json
 import os
-from typing import Dict, Any, List, Optional
-from datetime import datetime
+from typing import Dict, Any, Optional
 import logging
 import os
 from dotenv import load_dotenv
@@ -92,6 +91,7 @@ class ChatHistoryService:
                 "awaiting_slot": last_state.get("awaiting_slot"),
                 "intent": last_state.get("intent"),
                 "task_title": last_state.get("task_title"),
+                "has_fetched_schedule": last_state.get("has_fetched_schedule", False),
             }
     
     async def save_message(

--- a/core/state.py
+++ b/core/state.py
@@ -25,3 +25,4 @@ class ConversationState(TypedDict):
     schedule_ready: Optional[bool]
     user_feedback: Optional[str]  # recommend, generate, other
     type: Optional[str]
+    has_fetched_schedule: Optional[bool]  # 일정 조회 중복 방지 플래그

--- a/core/utils.py
+++ b/core/utils.py
@@ -72,12 +72,17 @@ def merge_task_title(old_title, new_title):
 def stream_llm_chunks(stream, writer=None, message_type="stream", message_key="message"):
     response_chunks = []
     for chunk in stream:
+        if chunk is None:
+            continue  # break 대신 continue
         content = extract_content(chunk)
-        if content is not None:
+        if content is not None and content != "":
             content_str = str(content)
             response_chunks.append(content_str)
             if writer:
                 writer({"type": message_type, message_key: content_str})
+        # 종료 조건: subtask_end 등 명확한 신호만 break
+        if isinstance(chunk, dict) and chunk.get("type") == "subtask_end":
+            break
     return "".join(response_chunks) 
 
 def safe_convert(obj):

--- a/model/json_parsed.py
+++ b/model/json_parsed.py
@@ -39,7 +39,6 @@ generate_format_instructions = generate_parser.get_format_instructions()
 
 # 쿼리 parser
 query_schemas = [
-    ResponseSchema(name="user_id", description="user_id"),
     ResponseSchema(name="start", description="시작 시간"),
     ResponseSchema(name="end", description="종료 시간"),
     ResponseSchema(name="task_title_keyword", description="task_title_keyword"),

--- a/model/prompt_template.py
+++ b/model/prompt_template.py
@@ -252,7 +252,7 @@ slot_recommendation_prompt = PromptTemplate(
 1. 'other'이외의 카테고리는 현재 비어있거나 recommend로 추출된 슬롯을 중점으로 추천하되, 대화 기록과 사용자 입력도 참고해주세요.
 
 2. 슬롯 종류
-- period: 기간(예: 3일, 일주일, 한달 등)
+- period: 기간(예: 내일(1일), 3일, 일주일, 한달 등)
 - duration_minutes: 하루 예상 소요 시간(예: 1시간), 시작 및 종료 시간(예: 09:00-10:00)
 - preferred_time: 선호 시간대
 - deadline: 마감일(YYYY-MM-DD)


### PR DESCRIPTION
## ☝️Issue Number
- resolve #91 

## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [X] 기타 사소한 수정

## 📌 개요
### 문제 현상
- fetch_schedules()가 무한 반복 호출됨.
- 호출 파라미터(특히 날짜)가 고정되어 계속 같은 쿼리로 요청이 감
- 서버를 수동으로 끄기 전까지 200 OK 응답이 계속 오며, 상태머신은 이를 정상으로 인식
- 상태 전이(transition)가 멈추지 않고 루프 상태로 일정 조회를 반복

### 수정
- has_fetched_schedule이 True면 더 이상 CalendarQueryNode로 진입하지 않도록 상태그래프 전이 조건 보완, 일정 조회 완료 후 False로 초기화하여 사용자의 새 입력에 대응할 수 있도록 수정
-  상태 플래그의 일관성 있는 관리: 모든 노드에서 dict(state, ...)로 반환하도록 통일

## ✅ 체크 리스트
- [X] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [X] PR이 관련 이슈를 정확히 참조하고, 적절한 라벨을 선택했습니다.
- [X] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 WIKI에 업데이트했습니다.
- [X] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.