### PR TITLE
fix: ASSISTANT 중복 저장 수정 (#93)

### DIFF
--- a/core/chat_graph.py
+++ b/core/chat_graph.py
@@ -133,7 +133,6 @@ class ChatGraphBuilder:
         self.graph_builder.add_edge("calendar_query", END)
 
     def compile(self):
-        logger.info("[ChatGraphBuilder] compile() called. Compiling chat graph.")
         self.add_node()
         self.set_entry_point()
         self.add_conditional_edges()

--- a/core/utils.py
+++ b/core/utils.py
@@ -73,14 +73,13 @@ def stream_llm_chunks(stream, writer=None, message_type="stream", message_key="m
     response_chunks = []
     for chunk in stream:
         if chunk is None:
-            continue  # break 대신 continue
+            continue 
         content = extract_content(chunk)
         if content is not None and content != "":
             content_str = str(content)
             response_chunks.append(content_str)
             if writer:
                 writer({"type": message_type, message_key: content_str})
-        # 종료 조건: subtask_end 등 명확한 신호만 break
         if isinstance(chunk, dict) and chunk.get("type") == "subtask_end":
             break
     return "".join(response_chunks) 


### PR DESCRIPTION
## ☝️Issue Number
- resolve #93 

## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [X] 기타 사소한 수정

## 📌 개요
- 챗봇 루프 내에서 이미 저장된 ASSISTANT 메시지가, 루프 종료 후에도 last_state로 한 번 더 저장되어 동일한 메시지가 DB에 두 번 기록되는 현상이 발생하여 마지막 응답에만 저장되도록 수정함
- 최종 응답된 일정도 subtask를 한 번에 묶어 저장되도록 수정

## ✅ 체크 리스트
- [X] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [X] PR이 관련 이슈를 정확히 참조하고, 적절한 라벨을 선택했습니다.
- [X] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 WIKI에 업데이트했습니다.
- [X] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.